### PR TITLE
[UT 4.2.1] Add unit tests for calorie filter

### DIFF
--- a/soaeco-soen341_project_w26/tests/4.2.calorie-filter.test.tsx
+++ b/soaeco-soen341_project_w26/tests/4.2.calorie-filter.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SearchPage from '../app/search_page/page';
+
+const mockPush = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+describe('4.2 calorie filter', () => {
+  const recipes = [
+    {
+      id: 'r1',
+      title: 'Low Cal',
+      prep_time: 10,
+      ingredients: [{ name: 'A', calories: 50 }],
+      restrictions: [],
+      cost: 5,
+      difficulty: 1,
+      preparation_steps: '',
+    },
+    {
+      id: 'r2',
+      title: 'High Cal',
+      prep_time: 10,
+      ingredients: [{ name: 'B', calories: 300 }],
+      restrictions: [],
+      cost: 5,
+      difficulty: 1,
+      preparation_steps: '',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelect.mockResolvedValue({ data: recipes, error: null });
+  });
+
+  it('filters by max calories', async () => {
+    render(React.createElement(SearchPage));
+
+    await screen.findByText('Low Cal');
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getByLabelText(/max calories/i), {
+      target: { value: '100' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    expect(screen.getByText('Low Cal')).toBeInTheDocument();
+    expect(screen.queryByText('High Cal')).not.toBeInTheDocument();
+  });
+
+  it('clear all resets filter', async () => {
+    render(React.createElement(SearchPage));
+
+    await screen.findByText('Low Cal');
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getByLabelText(/max calories/i), {
+      target: { value: '100' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    expect(screen.getByText('High Cal')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

This PR adds unit test coverage for the calorie filter feature on the recipe search page.

## Covered user stories
- US 4.2 User should be able to filter recipes by calorie amount

## What was tested
- displays recipe calorie totals
- filters recipes by max calories
- keeps recipes at or under the entered calorie limit
- only applies calorie filter after clicking Apply Filters
- combines calorie filter with existing filters
- resets calorie filter with Clear All
- shows no results when no recipes match

## Type of change
- [x] New feature
- [x] Unit tests

## How has this been tested?
- [x] Unit tests
- [x] Manual testing

