### PR TITLE
Feature/daily calorie test

### DIFF
--- a/soaeco-soen341_project_w26/tests/3.4.dailycaloriegoal.weeklyplanner.tsx
+++ b/soaeco-soen341_project_w26/tests/3.4.dailycaloriegoal.weeklyplanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import WeeklyPlanner from '../app/weekly_planner/page';
 

--- a/soaeco-soen341_project_w26/tests/3.4.dailycaloriegoal.weeklyplanner.tsx
+++ b/soaeco-soen341_project_w26/tests/3.4.dailycaloriegoal.weeklyplanner.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import WeeklyPlanner from '../app/weekly_planner/page';
+
+const mockGetWeeklyPlanner = jest.fn();
+const mockGetRecipes = jest.fn();
+const mockGetSession = jest.fn();
+const mockSingle = jest.fn();
+
+jest.mock('../lib/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+jest.mock('../app/weekly_planner/actions', () => ({
+  getWeeklyPlanner: (...args: unknown[]) => mockGetWeeklyPlanner(...args),
+  updateWeeklyPlannerMeal: jest.fn(),
+  resetWeeklyPlanner: jest.fn(),
+}));
+
+jest.mock('../app/recipe/actions', () => ({
+  getRecipes: () => mockGetRecipes(),
+}));
+
+jest.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getSession: () => mockGetSession() },
+    from: () => ({
+      select: () => ({
+        eq: () => ({ single: mockSingle }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('../lib/weeklyPlanner', () => ({
+  createEmptyPlannerGrid: () => ({
+    Monday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Tuesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Wednesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Thursday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Friday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Saturday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Sunday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+  }),
+}));
+
+function setup(recipeCalories: number, dailyGoal: number | null) {
+  mockGetSession.mockResolvedValue({
+    data: { session: { access_token: 't' } },
+    error: null,
+  });
+
+  mockGetWeeklyPlanner.mockResolvedValue({
+    success: true,
+    grid: {
+      Monday: {
+        Breakfast: { recipeId: 'r1' },
+        Lunch: { recipeId: null },
+        Dinner: { recipeId: null },
+        Snack: { recipeId: null },
+      },
+      Tuesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      Wednesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      Thursday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      Friday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      Saturday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      Sunday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    },
+    message: 'Planner loaded.',
+  });
+
+  mockGetRecipes.mockResolvedValue({
+    success: true,
+    recipes: [
+      {
+        id: 'r1',
+        title: 'Recipe 1',
+        ingredients: [{ calories: recipeCalories }],
+      },
+    ],
+  });
+
+  mockSingle.mockResolvedValue({
+    data: { daily_calorie_goal: dailyGoal },
+    error: null,
+  });
+}
+
+describe('daily calorie goal status', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows within limit when total calories are below the daily goal', async () => {
+    setup(500, 1000);
+
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/500 \/ 1000 cal/i)).toBeInTheDocument();
+      expect(screen.getByText(/within limit/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows near max when total calories reach 75% of the daily goal', async () => {
+    setup(800, 1000);
+
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/800 \/ 1000 cal/i)).toBeInTheDocument();
+      expect(screen.getByText(/near max/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows at or above max when total calories meet or exceed the daily goal', async () => {
+    setup(1200, 1000);
+
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1200 \/ 1000 cal/i)).toBeInTheDocument();
+      expect(screen.getByText(/at or above max/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows no max set when the user has no daily calorie goal', async () => {
+    setup(500, null);
+
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/500 \/ — cal/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/no max set/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/soaeco-soen341_project_w26/tests/4.1.weekly.calorie.goal.test.tsx
+++ b/soaeco-soen341_project_w26/tests/4.1.weekly.calorie.goal.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import WeeklyPlanner from '../app/weekly_planner/page';
+
+const mockGetWeeklyPlanner = jest.fn();
+const mockGetRecipes = jest.fn();
+const mockGetSession = jest.fn();
+const mockSingle = jest.fn();
+
+jest.mock('../lib/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+jest.mock('../app/weekly_planner/actions', () => ({
+  getWeeklyPlanner: (...args: unknown[]) => mockGetWeeklyPlanner(...args),
+  updateWeeklyPlannerMeal: jest.fn(),
+  resetWeeklyPlanner: jest.fn(),
+}));
+
+jest.mock('../app/recipe/actions', () => ({
+  getRecipes: () => mockGetRecipes(),
+}));
+
+jest.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: { getSession: () => mockGetSession() },
+    from: () => ({
+      select: () => ({
+        eq: () => ({ single: mockSingle }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('../lib/weeklyPlanner', () => ({
+  createEmptyPlannerGrid: () => ({
+    Monday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Tuesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Wednesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Thursday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Friday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Saturday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+    Sunday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+  }),
+}));
+
+describe('4.1 weekly calories', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 't' } },
+      error: null,
+    });
+
+    mockGetWeeklyPlanner.mockResolvedValue({
+      success: true,
+      grid: {
+        Monday: { Breakfast: { recipeId: 'r1' }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Tuesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Wednesday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Thursday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Friday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Saturday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+        Sunday: { Breakfast: { recipeId: null }, Lunch: { recipeId: null }, Dinner: { recipeId: null }, Snack: { recipeId: null } },
+      },
+      message: 'Planner loaded.',
+    });
+
+    mockGetRecipes.mockResolvedValue({
+      success: true,
+      recipes: [
+        {
+          id: 'r1',
+          title: 'Recipe 1',
+          ingredients: [{ calories: 200 }],
+        },
+      ],
+    });
+
+    mockSingle.mockResolvedValue({
+      data: { daily_calorie_goal: 1000 },
+      error: null,
+    });
+  });
+
+  it('shows daily calories', async () => {
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/200.*1000/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows weekly total', async () => {
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getByText(/200.*7000/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows no max if no goal', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: { daily_calorie_goal: null },
+      error: null,
+    });
+
+    render(React.createElement(WeeklyPlanner));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/no max set/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/soaeco-soen341_project_w26/tests/4.2.calorie-filter.test.tsx
+++ b/soaeco-soen341_project_w26/tests/4.2.calorie-filter.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SearchPage from '../app/search_page/page';
+
+const mockPush = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+describe('4.2 calorie filter', () => {
+  const recipes = [
+    {
+      id: 'r1',
+      title: 'Low Cal',
+      prep_time: 10,
+      ingredients: [{ name: 'A', calories: 50 }],
+      restrictions: [],
+      cost: 5,
+      difficulty: 1,
+      preparation_steps: '',
+    },
+    {
+      id: 'r2',
+      title: 'High Cal',
+      prep_time: 10,
+      ingredients: [{ name: 'B', calories: 300 }],
+      restrictions: [],
+      cost: 5,
+      difficulty: 1,
+      preparation_steps: '',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelect.mockResolvedValue({ data: recipes, error: null });
+  });
+
+  it('filters by max calories', async () => {
+    render(React.createElement(SearchPage));
+
+    await screen.findByText('Low Cal');
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getByLabelText(/max calories/i), {
+      target: { value: '100' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    expect(screen.getByText('Low Cal')).toBeInTheDocument();
+    expect(screen.queryByText('High Cal')).not.toBeInTheDocument();
+  });
+
+  it('clear all resets filter', async () => {
+    render(React.createElement(SearchPage));
+
+    await screen.findByText('Low Cal');
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getByLabelText(/max calories/i), {
+      target: { value: '100' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    expect(screen.getByText('High Cal')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Description
This PR adds unit test coverage for the planner’s daily calorie goal status feature.

Covered user stories
US 3.4 User should be able to see whether their daily calorie goal is met

What was tested
retrieves the user’s daily calorie goal when the planner loads
calculates total daily calories from recipe ingredient data
displays daily calories relative to the saved daily goal
shows “Within limit” when calories are below the daily goal
shows “Near max” when calories are close to the daily goal
shows “At or above max” when calories meet or exceed the daily goal
handles case where no daily calorie goal is set by displaying “No max set”

Type of change
 New feature
 Unit tests

How has this been tested?
 Unit tests
 Manual testing