### PR TITLE
UTs for Front End Sprint 3

### DIFF
--- a/soaeco-soen341_project_w26/lib/weeklyPlannerUi.ts
+++ b/soaeco-soen341_project_w26/lib/weeklyPlannerUi.ts
@@ -1,0 +1,129 @@
+import type {
+  PlannerDayType,
+  PlannerMealType,
+  WeeklyPlannerGrid,
+} from "./types";
+import { createEmptyPlannerGrid } from "./weeklyPlanner";
+
+export const plannerDays: PlannerDayType[] = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+export const plannerMeals: PlannerMealType[] = [
+  "Breakfast",
+  "Lunch",
+  "Dinner",
+  "Snack",
+];
+
+export const getPlannerSlotCount = (): number => {
+  return plannerDays.length * plannerMeals.length;
+};
+
+export const isPlannerSlotEmpty = (
+  planner: WeeklyPlannerGrid,
+  day: PlannerDayType,
+  meal: PlannerMealType,
+): boolean => {
+  return planner[day][meal].recipeId === null;
+};
+
+export const getFilledPlannerSlotsCount = (
+  planner: WeeklyPlannerGrid,
+): number => {
+  let count = 0;
+
+  for (const day of plannerDays) {
+    for (const meal of plannerMeals) {
+      if (planner[day][meal].recipeId) {
+        count += 1;
+      }
+    }
+  }
+
+  return count;
+};
+
+export const getUsedRecipeIds = (
+  planner: WeeklyPlannerGrid,
+): Set<string> => {
+  const usedRecipeIds = new Set<string>();
+
+  for (const day of plannerDays) {
+    for (const meal of plannerMeals) {
+      const recipeId = planner[day][meal].recipeId;
+      if (recipeId) {
+        usedRecipeIds.add(recipeId);
+      }
+    }
+  }
+
+  return usedRecipeIds;
+};
+
+export const isRecipeAlreadyUsed = (
+  planner: WeeklyPlannerGrid,
+  recipeId: string,
+): boolean => {
+  return getUsedRecipeIds(planner).has(recipeId);
+};
+
+export const canAddRecipeToPlanner = (input: {
+  hasUser: boolean;
+  selectedDay: PlannerDayType | null;
+  selectedMeal: PlannerMealType | null;
+  planner: WeeklyPlannerGrid;
+  recipeId: string;
+}): boolean => {
+  if (!input.hasUser) return false;
+  if (!input.selectedDay || !input.selectedMeal) return false;
+  if (isRecipeAlreadyUsed(input.planner, input.recipeId)) return false;
+
+  return true;
+};
+
+export const applyRecipeToPlanner = (
+  planner: WeeklyPlannerGrid,
+  day: PlannerDayType,
+  meal: PlannerMealType,
+  recipeId: string,
+  recipeTitle: string,
+): WeeklyPlannerGrid => {
+  return {
+    ...planner,
+    [day]: {
+      ...planner[day],
+      [meal]: {
+        recipeId,
+        recipeTitle,
+      },
+    },
+  };
+};
+
+export const removeRecipeFromPlanner = (
+  planner: WeeklyPlannerGrid,
+  day: PlannerDayType,
+  meal: PlannerMealType,
+): WeeklyPlannerGrid => {
+  return {
+    ...planner,
+    [day]: {
+      ...planner[day],
+      [meal]: {
+        recipeId: null,
+        recipeTitle: null,
+      },
+    },
+  };
+};
+
+export const resetPlannerGrid = (): WeeklyPlannerGrid => {
+  return createEmptyPlannerGrid();
+};

--- a/soaeco-soen341_project_w26/tests/3.1.weekly.planner.ui.test.ts
+++ b/soaeco-soen341_project_w26/tests/3.1.weekly.planner.ui.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+import { createEmptyPlannerGrid } from "../lib/weeklyPlanner";
+import {
+  applyRecipeToPlanner,
+  getFilledPlannerSlotsCount,
+  getPlannerSlotCount,
+  isPlannerSlotEmpty,
+} from "../lib/weeklyPlannerUi";
+
+describe("3.1 weekly planner frontend ui state", () => {
+  it("starts with 28 empty planner slots", () => {
+    const planner = createEmptyPlannerGrid();
+
+    expect(getPlannerSlotCount()).toBe(28);
+    expect(getFilledPlannerSlotsCount(planner)).toBe(0);
+    expect(isPlannerSlotEmpty(planner, "Monday", "Breakfast")).toBe(true);
+    expect(isPlannerSlotEmpty(planner, "Sunday", "Snack")).toBe(true);
+  });
+
+  it("marks a slot as filled after a recipe is placed in the planner", () => {
+    const planner = applyRecipeToPlanner(
+      createEmptyPlannerGrid(),
+      "Monday",
+      "Breakfast",
+      "recipe-1",
+      "Omelette",
+    );
+
+    expect(getFilledPlannerSlotsCount(planner)).toBe(1);
+    expect(isPlannerSlotEmpty(planner, "Monday", "Breakfast")).toBe(false);
+    expect(planner.Monday.Breakfast).toEqual({
+      recipeId: "recipe-1",
+      recipeTitle: "Omelette",
+    });
+  });
+});

--- a/soaeco-soen341_project_w26/tests/3.2.integrated.daily.meal.planner.test.ts
+++ b/soaeco-soen341_project_w26/tests/3.2.integrated.daily.meal.planner.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+import { createEmptyPlannerGrid } from "../lib/weeklyPlanner";
+import {
+  applyRecipeToPlanner,
+  canAddRecipeToPlanner,
+  getUsedRecipeIds,
+  isRecipeAlreadyUsed,
+} from "../lib/weeklyPlannerUi";
+
+describe("3.2 integrated daily meal planner frontend duplicate tracking", () => {
+  it("collects all used recipe ids currently assigned in the week", () => {
+    let planner = createEmptyPlannerGrid();
+
+    planner = applyRecipeToPlanner(
+      planner,
+      "Monday",
+      "Breakfast",
+      "recipe-1",
+      "Omelette",
+    );
+
+    planner = applyRecipeToPlanner(
+      planner,
+      "Tuesday",
+      "Lunch",
+      "recipe-2",
+      "Soup",
+    );
+
+    expect(Array.from(getUsedRecipeIds(planner)).sort()).toEqual([
+      "recipe-1",
+      "recipe-2",
+    ]);
+  });
+
+  it("detects when a recipe is already assigned somewhere in the same week", () => {
+    const planner = applyRecipeToPlanner(
+      createEmptyPlannerGrid(),
+      "Monday",
+      "Breakfast",
+      "recipe-1",
+      "Omelette",
+    );
+
+    expect(isRecipeAlreadyUsed(planner, "recipe-1")).toBe(true);
+    expect(isRecipeAlreadyUsed(planner, "recipe-2")).toBe(false);
+  });
+
+  it("allows adding a recipe only when user and slot are selected and the recipe is not already used", () => {
+    const planner = applyRecipeToPlanner(
+      createEmptyPlannerGrid(),
+      "Monday",
+      "Breakfast",
+      "recipe-1",
+      "Omelette",
+    );
+
+    expect(
+      canAddRecipeToPlanner({
+        hasUser: true,
+        selectedDay: "Tuesday",
+        selectedMeal: "Lunch",
+        planner,
+        recipeId: "recipe-2",
+      }),
+    ).toBe(true);
+
+    expect(
+      canAddRecipeToPlanner({
+        hasUser: true,
+        selectedDay: "Tuesday",
+        selectedMeal: "Lunch",
+        planner,
+        recipeId: "recipe-1",
+      }),
+    ).toBe(false);
+
+    expect(
+      canAddRecipeToPlanner({
+        hasUser: false,
+        selectedDay: "Tuesday",
+        selectedMeal: "Lunch",
+        planner,
+        recipeId: "recipe-2",
+      }),
+    ).toBe(false);
+  });
+});

--- a/soaeco-soen341_project_w26/tests/3.3.add.remove.planned.recipe.test.ts
+++ b/soaeco-soen341_project_w26/tests/3.3.add.remove.planned.recipe.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { createEmptyPlannerGrid } from "../lib/weeklyPlanner";
+import {
+  applyRecipeToPlanner,
+  removeRecipeFromPlanner,
+  resetPlannerGrid,
+} from "../lib/weeklyPlannerUi";
+
+describe("3.3 add remove planned recipe frontend state changes", () => {
+  it("adds a recipe to the selected planner slot", () => {
+    const planner = applyRecipeToPlanner(
+      createEmptyPlannerGrid(),
+      "Wednesday",
+      "Dinner",
+      "recipe-9",
+      "Pasta",
+    );
+
+    expect(planner.Wednesday.Dinner).toEqual({
+      recipeId: "recipe-9",
+      recipeTitle: "Pasta",
+    });
+  });
+
+  it("removes a recipe from the selected planner slot", () => {
+    const planner = applyRecipeToPlanner(
+      createEmptyPlannerGrid(),
+      "Wednesday",
+      "Dinner",
+      "recipe-9",
+      "Pasta",
+    );
+
+    const updatedPlanner = removeRecipeFromPlanner(
+      planner,
+      "Wednesday",
+      "Dinner",
+    );
+
+    expect(updatedPlanner.Wednesday.Dinner).toEqual({
+      recipeId: null,
+      recipeTitle: null,
+    });
+
+    expect(planner.Wednesday.Dinner).toEqual({
+      recipeId: "recipe-9",
+      recipeTitle: "Pasta",
+    });
+  });
+
+  it("resets the weekly planner back to an empty grid", () => {
+    let planner = createEmptyPlannerGrid();
+
+    planner = applyRecipeToPlanner(
+      planner,
+      "Monday",
+      "Breakfast",
+      "recipe-1",
+      "Omelette",
+    );
+
+    planner = applyRecipeToPlanner(
+      planner,
+      "Friday",
+      "Snack",
+      "recipe-2",
+      "Fruit Bowl",
+    );
+
+    const resetPlanner = resetPlannerGrid();
+
+    expect(resetPlanner).toEqual(createEmptyPlannerGrid());
+    expect(resetPlanner).not.toBe(planner);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the problem that is being solved. -->
<!-- Please also include relevant motivation and context. -->

## Related Issue

<!-- This PR addresses the following issue. -->
<!-- Please link the issue here and use `Closes #issue-number` to automatically close it. -->
<!-- If this PR only partially addresses an issue, use `Relates to #issue-number` instead. -->

Closes #
#181 
#182 
#183 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Chore (build process, dependencies, etc.)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so reviewers can reproduce. -->

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests

**Test Configuration:**
- Browser (if applicable):
- Node version:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- If your changes are visual, please add screenshots or GIFs here. -->


## Additional Notes

<!-- Any additional information that reviewers should know. -->
PS C:\Users\corre\OneDrive\Desktop\SOEN 341\PROJECT\SOEN-341-LAB-UM-X-SOEN341_Project_W26\soaeco-soen341_project_w26> npm test

> soaeco-soen341_project_w26@0.1.1 test
> jest --watchman=false


 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.2.weekly.planner.assignment.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.3.weekly.planner.duplicate.update.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.1.weekly.planner.retrieval.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.2.integrated.daily.meal.planner.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.3.add.remove.planned.recipe.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/3.5.calories.actions.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/2.1.recipe.actions.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/4.4.recipe.actions.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 RUNS  tests/1.1.register.test.ts
 RUNS  tests/4.4.recipe.actions.test.ts
 RUNS  tests/2.1.recipe.actions.test.ts
 RUNS  tests/4.1.weekly.calorie.goal.test.tsx

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 PASS  tests/2.2.search.api.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 PASS  tests/4.4.ingredients.api.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 PASS  tests/search.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts
 PASS  tests/3.1.weekly.planner.ui.test.ts

 RUNS  tests/2.1.recipe.page.test.ts
 RUNS  tests/4.3.weekly_planner.generation.test.ts
 RUNS  tests/2.3.filters.test.ts
 RUNS  tests/1.3.profile_management.test.ts

 PASS  tests/filterRecipesBySearch.test.ts

 PASS  tests/sanity.test.js

 PASS  tests/toggleItem.test.ts

 PASS  tests/2.2.navigation.test.ts
 PASS  tests/1.2.login.test.ts
 PASS  tests/4.1.weekly.calorie.goal.test.tsx
 PASS  tests/1.1.register.test.ts
 PASS  tests/4.2.calorie-filter.test.tsx
 PASS  tests/2.2.search.page.test.ts
 PASS  tests/4.3.weekly_planner.generation.test.ts
 PASS  tests/1.3.profile_management.test.ts
 PASS  tests/2.3.filters.test.ts
 PASS  tests/2.1.recipe.page.test.ts

Test Suites: 25 passed, 25 total
Tests:       74 passed, 74 total
Snapshots:   0 total
Time:        6.292 s
Ran all test suites.